### PR TITLE
Rework summary message to handle percentiles that straddle the middle

### DIFF
--- a/js/mission-quiz.js
+++ b/js/mission-quiz.js
@@ -144,16 +144,12 @@ function handleUpdateNumCorrectCallback(response) {
         }
     }
 
-    let level = 'top';
     let totalUsers = numUsersLess + numUsersEqual + numUsersMore;
-    let percentile = Math.round((numUsersEqual + numUsersMore) * 100 / totalUsers);
-    if (percentile >= 50) {
-        percentile = Math.round((numUsersEqual + numUsersLess) * 100 / totalUsers);
-        level = 'bottom';
-    }
+    let more_percentage = Math.round(100 * numUsersMore / totalUsers);
+    let less_percentage = Math.round(100 * numUsersLess / totalUsers);
 
     const percentileContainer = document.getElementById('percentile');
-    percentileContainer.innerHTML = `<p>You scored in the ${level} ${percentile} percent of everyone who has taken the quiz.</p>`;
+    percentileContainer.innerHTML = `<p>Of everyone who has taken the quiz ${more_percentage}% had more correct answers,<br/>and ${less_percentage}% had fewer correct answers than you.</p>`;
 }
 
 // build quiz function


### PR DESCRIPTION
There will virtually always be some quiz score that straddles the 50 percentile mark. For example, assume the groups of 5-, 6-, and 7-correct answers contain 45% of the test takers, and the groups of 1-, 2-, and 3-correct answers contain 35% of the test takers. Then those who scored 4 correct answers are 20% of the test takers and are in both the top 65% and the bottom 55% of test takers. This does not read well when presented as a result.

This commit tries to resolve the issue by presenting the user with two values, the percentage of test takers who did better, and the percentage of test takers who did worse. An example is shown below

```
Of everyone who has taken the quiz 37% had more correct answers,
and 49% had fewer correct answers than you.
```